### PR TITLE
LinkedData typo error when defining attribute

### DIFF
--- a/src/angular-fusioncharts.js
+++ b/src/angular-fusioncharts.js
@@ -33,7 +33,7 @@
                 dataset: '@',
                 categories: '@',
                 chart: '@',
-                linkdedata: '@',
+                linkeddata: '@',
                 trendlines: '@',
                 vtrendlines: '@',
                 annotations: '@',


### PR DESCRIPTION
There was a tipo error in the definition of the attribute linkeddata, so it was not working
