### PR TITLE
Release resources in $on('$destroy') - fixes major memory leak

### DIFF
--- a/src/angular-fusioncharts.js
+++ b/src/angular-fusioncharts.js
@@ -451,6 +451,12 @@
 
                 createFCChart();
 
+                scope.$on('$destroy', function () {
+                   // on destroy free used resources to avoid memory leaks
+                   if (chart && chart.dispose) {
+                      chart.dispose();
+                   }
+                });
             }
         };
     }]);


### PR DESCRIPTION
Free FusionChart resources on directive destruction. Fixes memory leakage (see attached images).

Before:
![beforefix](https://cloud.githubusercontent.com/assets/2143625/16112670/acdcd6f8-33b8-11e6-8115-25c626fd3ca5.PNG)
After:
![afterfix](https://cloud.githubusercontent.com/assets/2143625/16112671/acdd1118-33b8-11e6-8c57-05d5f71d121e.PNG)

PS: There still seems to be some memory leak
