### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
-#AngularJS Charts Plugin
+# AngularJS Charts Plugin
 
 Simple and effective AngularJS charts plugin for FusionCharts.
 
-###Details
+### Details
 Use this AngularJS charts plugin to add interactive charts to your web and mobile applications using just a single directive. Choose from 90+ charts & 900+ maps from FusionCharts' core [JavaScript charts](http://www.fusioncharts.com/) library.
 
  You can access all the rich charting features like events, annotations, macros, themes, image-export etc. to make your visualizations stand-out.
 
-###Demos
+### Demos
 To learn what you can do using this Angular charts plugin, explore some [live demos](http://www.fusioncharts.com/angularjs-charts/).
 
-###Tutorial
+### Tutorial
 
 Following tutorials will help you get started:
 
 - Official blog post on using this plugin: [adding charts to your AngularJS app](http://www.fusioncharts.com/blog/2015/03/angular-fusioncharts/).
 - Tutorial by a user of this plugin: [How to Build Charts in Angular](https://davidwalsh.name/angular-charts)
 
-###Documentation
+### Documentation
 To dive deeper, please view the [official documentation](http://www.fusioncharts.com/dev/using-with-javascript-libraries/angularjs/introduction.html).
 
 
-###Features
+### Features
 
  - Add a chart using just a single directive. 
  - Auto-updates your chart object on modifying scope. 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
