### PR TITLE
Fixed implicitly declared var attrConfig

### DIFF
--- a/src/angular-fusioncharts.js
+++ b/src/angular-fusioncharts.js
@@ -370,6 +370,7 @@
                     dataStringStore = {},
                     i,
                     attr,
+                    attrConfig,
                     _eobj,
                     key,
                     observableAttr,


### PR DESCRIPTION
The `attrConfig` variable was being implicitly declared. Fixed this.